### PR TITLE
 Fix start signature adding Termination

### DIFF
--- a/cortex-m-qemu/src/lang_items.rs
+++ b/cortex-m-qemu/src/lang_items.rs
@@ -23,6 +23,7 @@ impl Termination for () {
 
 
 #[lang = "panic_fmt"]
+#[no_mangle]
 unsafe extern "C" fn panic_fmt(args: ::core::fmt::Arguments,
                                file: &'static str,
                                line: u32)

--- a/cortex-m-qemu/src/lang_items.rs
+++ b/cortex-m-qemu/src/lang_items.rs
@@ -23,7 +23,6 @@ impl Termination for () {
 
 
 #[lang = "panic_fmt"]
-#[no_mangle]
 unsafe extern "C" fn panic_fmt(args: ::core::fmt::Arguments,
                                file: &'static str,
                                line: u32)

--- a/cortex-m-qemu/src/lang_items.rs
+++ b/cortex-m-qemu/src/lang_items.rs
@@ -1,14 +1,26 @@
 use core::intrinsics;
 
 #[lang = "start"]
-extern "C" fn start(main: fn(),
-                    _argc: isize,
-                    _argv: *const *const u8)
-                    -> isize {
+extern "C" fn start<T>(main: fn() -> T, _argc: isize, _argv: *const *const u8) -> isize
+where
+    T: Termination,
+{
     main();
 
     0
 }
+
+#[lang = "termination"]
+pub trait Termination {
+    fn report(self) -> i32;
+}
+
+impl Termination for () {
+    fn report(self) -> i32 {
+        0
+    }
+}
+
 
 #[lang = "panic_fmt"]
 unsafe extern "C" fn panic_fmt(args: ::core::fmt::Arguments,


### PR DESCRIPTION
Fix `start` signature to avoid this ICE:

```
error: internal compiler error: librustc_metadata/cstore_impl.rs:131: get_optimized_mir: missing
MIR forDefId(3/0:10 ~ utest_cortex_m_qemu[f0f1]::lang_items[0]::start[0]
```
PR is needed to fix `rust-lang-nursery/compiler-builtins` tests on TravisCI for thumb* targets

