### PR TITLE
Add assert_test_result required by latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,20 @@ pub fn test_main_static(tests: &[TestDescAndFn]) {
     }
 }
 
+pub trait Termination {
+    fn report(self) -> i32;
+}
+
+impl Termination for () {
+    fn report(self) -> i32 {
+        0
+    }
+}
+
+pub fn assert_test_result<T: Termination>(result: T) {
+    assert_eq!(result.report(), 0);
+}
+
 // required for compatibility with the `rustc --test` interface
 pub struct TestDescAndFn {
     pub desc: TestDesc,


### PR DESCRIPTION
On recent nightly rather than directly give the test function
to the test harness, compiler  create a wrapper like this:

`     || test::assert_test_result(real_function())`

invoked when unit tests terminate

See [48143](https://github.com/rust-lang/rust/pull/48143) on rust-lang/rust